### PR TITLE
Add onMapInitializeEvent listener to automatically update map, fix plugin.yml dependency missing, add build instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,14 @@ You can reload the configs by reloading BlueMap itself, which is `/bluemap reloa
 To get support with this plugin, join the [BlueMap Discord server](https://bluecolo.red/map-discord)
 and ask your questions in [#3rd-party-support](https://discord.com/channels/665868367416131594/863844716047106068).  
 You're welcome to ping me, @TechnicJelle.
+
+# Build instructions
+* Install [Maven](https://maven.apache.org/download.cgi)
+* Clone this repository
+* Run `mvn clean install` in the root directory of the repository
+* The built jar file will be in the `target` directory
+
+### Auto Discover
+*New feature!*  Any time a map is created, it will be automatically discovered and synced with BlueMap.
+
+To opt in to this feature, set `auto-discover` to `true` in the `config.yml` file.

--- a/src/main/java/com/technicjelle/bluemapmcmapsync/PlayerMapHoldListener.java
+++ b/src/main/java/com/technicjelle/bluemapmcmapsync/PlayerMapHoldListener.java
@@ -1,0 +1,31 @@
+package com.technicjelle.bluemapmcmapsync;
+
+import com.technicjelle.bluemapmcmapsync.commands.BMDiscover;
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerItemHeldEvent;
+import org.bukkit.event.server.MapInitializeEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.map.MapView;
+import de.bluecolored.bluemap.api.BlueMapAPI;
+import de.bluecolored.bluemap.api.BlueMapMap;
+import org.bukkit.entity.Player;
+
+public class PlayerMapHoldListener implements Listener {
+
+	private final BlueMapMCMapSync plugin;
+
+	public PlayerMapHoldListener(BlueMapMCMapSync plugin) {
+		this.plugin = plugin; 
+		plugin.getLogger().info("PlayerMapHoldListener registered");
+	}
+
+	@EventHandler
+	public void onMapInitialize(MapInitializeEvent event) {
+		MapView mapView = event.getMap();
+		BMDiscover executor = plugin.getExecutor();
+		executor.discoverMap(mapView);
+	}
+}

--- a/src/main/java/com/technicjelle/bluemapmcmapsync/commands/BMDiscover.java
+++ b/src/main/java/com/technicjelle/bluemapmcmapsync/commands/BMDiscover.java
@@ -84,6 +84,47 @@ public class BMDiscover implements CommandExecutor, TabCompleter {
 		return false;
 	}
 
+	// This method is like the above, but does not require a sender.
+	// It will only be called if auto-discover is enabled in the config.yml file.
+	public void discoverMap(MapView mapView) {
+		if (mapView == null) {
+			return;
+		}
+		World world = mapView.getWorld();
+		if (world == null) {
+			return;
+		}
+		MapView.Scale scale = mapView.getScale();
+		int radius = getRadiusFromScale(scale);
+		if (radius == -1) {
+			return;
+		}
+		BlueMapAPI api = BlueMapAPI.getInstance().orElse(null);
+		if (api == null) {
+			return;
+		}
+		BlueMapWorld blueMapWorld = api.getWorld(world).orElse(null);
+		if (blueMapWorld == null) {
+			return;
+		}
+		if (blueMapWorld.getMaps().isEmpty()) {
+			return;
+		}
+
+		// Discover every BlueMap map of this world
+		for (BlueMapMap map : blueMapWorld.getMaps()) {
+			Square square = new Square(mapView.getCenterX(), mapView.getCenterZ(), radius, map);
+			if (plugin.addSquareToMap(square, map)) {
+				plugin.getLogger().info("Discovered another piece of " + map.getName() + "!");
+				for (Player player : plugin.getServer().getOnlinePlayers()) {
+					player.sendMessage("Another map piece of " + map.getName() + " has been discovered!");
+				}
+			} else {
+				plugin.getLogger().info("This part of " + map.getName() + " has already been discovered");
+			}
+		}
+	}
+
 	/**
 	 * @param scale the scale of the map
 	 * @return the radius of the map. -1 if the scale is not recognized

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -12,3 +12,5 @@ commands:
 permissions:
   bmdiscover:
     default: true
+
+depend: [BlueMap]


### PR DESCRIPTION
BlueMap not being added as a dependency was causing the plugin load order to be wrong:

```
[17:18:44 ERROR]: [ModernPluginLoadingStrategy] Could not load plugin 'BlueMapMCMapSync-0.1.jar' in folder 'plugins'
org.bukkit.plugin.InvalidPluginException: Exception initializing main class `com.technicjelle.bluemapmcmapsync.BlueMapMCMapSync'
        at org.bukkit.plugin.java.PluginClassLoader.<init>(PluginClassLoader.java:106) ~[paper-api-1.20.2-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.provider.type.spigot.SpigotPluginProvider.createInstance(SpigotPluginProvider.java:123) ~[paper-1.20.2.jar:git-Paper-318]
        at io.papermc.paper.plugin.provider.type.spigot.SpigotPluginProvider.createInstance(SpigotPluginProvider.java:35) ~[paper-1.20.2.jar:git-Paper-318]
        at io.papermc.paper.plugin.entrypoint.strategy.modern.ModernPluginLoadingStrategy.loadProviders(ModernPluginLoadingStrategy.java:116) ~[paper-1.20.2.jar:git-Paper-318]
        at io.papermc.paper.plugin.storage.SimpleProviderStorage.enter(SimpleProviderStorage.java:38) ~[paper-1.20.2.jar:git-Paper-318]
        at io.papermc.paper.plugin.entrypoint.LaunchEntryPointHandler.enter(LaunchEntryPointHandler.java:36) ~[paper-1.20.2.jar:git-Paper-318]
        at org.bukkit.craftbukkit.v1_20_R2.CraftServer.loadPlugins(CraftServer.java:514) ~[paper-1.20.2.jar:git-Paper-318]
        at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:273) ~[paper-1.20.2.jar:git-Paper-318]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1086) ~[paper-1.20.2.jar:git-Paper-318]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:315) ~[paper-1.20.2.jar:git-Paper-318]
        at java.lang.Thread.run(Thread.java:1583) ~[?:?]
Caused by: java.lang.reflect.InvocationTargetException
        at jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:74) ~[?:?]
        at java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502) ~[?:?]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:486) ~[?:?]
        at org.bukkit.plugin.java.PluginClassLoader.<init>(PluginClassLoader.java:98) ~[paper-api-1.20.2-R0.1-SNAPSHOT.jar:?]
        ... 10 more
Caused by: java.lang.NoClassDefFoundError: de/bluecolored/bluemap/api/BlueMapAPI
        at com.technicjelle.bluemapmcmapsync.BlueMapMCMapSync.<init>(BlueMapMCMapSync.java:61) ~[BlueMapMCMapSync-0.1.jar:?]
        at jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62) ~[?:?]
        at java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502) ~[?:?]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:486) ~[?:?]
        at org.bukkit.plugin.java.PluginClassLoader.<init>(PluginClassLoader.java:98) ~[paper-api-1.20.2-R0.1-SNAPSHOT.jar:?]
        ... 10 more
Caused by: java.lang.ClassNotFoundException: de.bluecolored.bluemap.api.BlueMapAPI
        at org.bukkit.plugin.java.PluginClassLoader.loadClass0(PluginClassLoader.java:197) ~[paper-api-1.20.2-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.java.PluginClassLoader.loadClass(PluginClassLoader.java:164) ~[paper-api-1.20.2-R0.1-SNAPSHOT.jar:?]
        at java.lang.ClassLoader.loadClass(ClassLoader.java:526) ~[?:?]
        at com.technicjelle.bluemapmcmapsync.BlueMapMCMapSync.<init>(BlueMapMCMapSync.java:61) ~[BlueMapMCMapSync-0.1.jar:?]
        at jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62) ~[?:?]
        at java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502) ~[?:?]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:486) ~[?:?]
        at org.bukkit.plugin.java.PluginClassLoader.<init>(PluginClassLoader.java:98) ~[paper-api-1.20.2-R0.1-SNAPSHOT.jar:?]
        ... 10 more
[17:18:44 INFO]: [BlueMap] Loading server plugin BlueMap v3.20
[17:18:44 INFO]: Server permissions file permissions.yml is empty, ignoring it
```

Adding BlueMap as a dependency in `plugin.yml` fixes this.

Also, I added the build instructions to the readme.  Feel free to delete that change from this pull request.